### PR TITLE
Revised boolean evaluation order in _get_nn_eqns_values so it will work when …

### DIFF
--- a/NRWAL/handlers/groups.py
+++ b/NRWAL/handlers/groups.py
@@ -325,13 +325,13 @@ class AbstractGroup(ABC):
         if i == (len(keys) - 1):
             # Only look for adjacent equations when were at the last
             # retrieval level in the EquationGroup
-            if (self._interp_extrap_power or self._use_nearest_power
+            if ((self._interp_extrap_power or self._use_nearest_power)
                     and self.is_power_eqn(eqn_key)):
                 nn_eqns, nn_values = \
                     self.find_nearest_power_eqns(eqn_key, group=group)
                 eqn_value = self._parse_power(eqn_key)[0]
 
-            elif (self._interp_extrap_year or self._use_nearest_year
+            elif ((self._interp_extrap_year or self._use_nearest_year)
                     and self.is_year_eqn(eqn_key)):
                 nn_eqns, nn_values = \
                     self.find_nearest_year_eqns(eqn_key, group=group)


### PR DESCRIPTION
…_interp_extrap_power and _interp_extrap_year are both True.

Was falling into the first if statement because it was evaluating as `if self._interp_extrap_power or (self._use_nearest_power and self.is_power_eqn(eqn_key))` and then returning empty lists which would cause:

![Screen Shot 2021-02-04 at 1 59 14 PM](https://user-images.githubusercontent.com/42254629/106956273-9d797180-66f3-11eb-8b2a-fbe0987d18fd.png)
